### PR TITLE
Update sqlite3 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'turbolinks',              '5.0.0'
 gem 'jbuilder',                '2.4.1'
 
 group :development, :test do
-  gem 'sqlite3', '1.3.11'
+  gem 'sqlite3', '1.3.12'
   gem 'byebug',  '9.0.0', platform: :mri
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,7 +170,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.11)
+    sqlite3 (1.3.12)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -210,11 +210,11 @@ DEPENDENCIES
   sass-rails (= 5.0.6)
   spring (= 1.7.2)
   spring-watcher-listen (= 2.0.0)
-  sqlite3 (= 1.3.11)
+  sqlite3 (= 1.3.12)
   turbolinks (= 5.0.0)
   tzinfo-data
   uglifier (= 3.0.0)
   web-console (= 3.1.1)
 
 BUNDLED WITH
-   1.13.2
+   1.13.6


### PR DESCRIPTION
Previous version was crashing Ruby on macOS Sierra when spring was used.

https://github.com/sparklemotion/sqlite3-ruby/issues/195